### PR TITLE
fix-deploy-action

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10.2
+FROM alpine:latest
 
 ENV BASE_URL="https://get.helm.sh"
 


### PR DESCRIPTION
deploy action is failing on project repositories due to inability to download packages from remote repository.
to fix the issue, changed the alpine image version from `3.10.2` to `latest`